### PR TITLE
Added gh command RUn poetry install on start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,17 +25,20 @@
 		},
 		"ghcr.io/devcontainers-contrib/features/tox:2": {
 			"version": "latest"
-		}
-	}
+		},
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "latest"
+        }
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+	"postCreateCommand": "poetry install"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
VS Code devcontainer is now initialized properly by running poetry install. Thus, all required Python tools can be found as the created virtual environment is activated automatically